### PR TITLE
Remove leaderboard and database dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # 🏅 Fiori Study Buddy
 
-A modern, mobile‑first quiz application designed to help SAP Fiori developers and consultants prepare for certifications and enhance their knowledge. The application features a clean, responsive interface with question banks, scoring system, and leaderboards backed by Cloudflare KV.
+A modern, mobile‑first quiz application designed to help SAP Fiori developers and consultants prepare for certifications and enhance their knowledge. The application features a clean, responsive interface with question banks and a detailed scoring system.
 
 ## ✨ Features
 
 - **Question Banks**: Organized quiz questions in manageable banks of 40 questions each
 - **Interactive Quiz Interface**: Modern, responsive UI built with Tailwind CSS
 - **Scoring System**: Track your progress with detailed scoring metrics
-- **Leaderboards**: Compete with others and track top performers
 - **Time Tracking**: Monitor how long it takes to complete quizzes
-- **Persistent Data**: Scores and leaderboards saved in Cloudflare KV
 
 ## 🚀 Quick Start
 
@@ -43,11 +41,6 @@ A modern, mobile‑first quiz application designed to help SAP Fiori developers 
    ```powershell
    wrangler deploy
    ```
-   Ensure a KV namespace named `LEADERBOARD` exists:
-   ```powershell
-   wrangler kv:namespace create LEADERBOARD
-   ```
-   and update `wrangler.toml` with the generated id.
 
 ## 📁 Project Structure
 
@@ -67,7 +60,6 @@ fioriPrepper/
 ## 🔧 Technical Stack
 
 - **Backend**: Cloudflare Worker using Hono
-- **Storage**: Cloudflare KV (in‑memory when running locally)
 - **Frontend**: Vanilla JavaScript with Tailwind CSS
 - **Module System**: ES6 modules
 
@@ -87,40 +79,16 @@ Retrieve questions from specific bank(s). Use comma-separated IDs for multiple b
 - Example: `/api/bank/1` (single bank)
 - Example: `/api/bank/1,2,3` (multiple banks)
 
-### Get Leaderboard
-```
-GET /api/leaderboard/:key
-```
-Retrieve top 10 scores for a specific quiz configuration.
-
-### Submit Score
-```
-POST /api/leaderboard/:key
-```
-Submit a new score to the leaderboard.
-
-**Request Body:**
-```json
-{
-  "name": "Player Name",
-  "score": 85,
-  "total": 100,
-  "time": 1500
-}
-```
 
 ## 🎯 How to Use
 
 1. **Start a Quiz**: Select your desired question banks from the interface
 2. **Answer Questions**: Work through the interactive quiz questions
 3. **Track Progress**: Monitor your score and time as you progress
-4. **Submit Results**: Enter your name to save your score to the leaderboard
-5. **View Rankings**: Check the leaderboard to see how you compare with others
 
 ## 🔒 Data Management
 
 - **Questions**: Stored in `data/questions.json` with a structured format including question text, answers, and correct answer indicators
-- **Leaderboards**: Saved in Cloudflare KV and synced automatically per quiz configuration
 - **Bank System**: Questions are automatically divided into banks of 40 questions each
 
 ## 🛠️ Configuration
@@ -132,8 +100,6 @@ Submit a new score to the leaderboard.
 ### Customization
 
 - **Bank Size**: Modify the `BANK_SIZE` constant in `worker.js` (default: 40)
-- **Leaderboard Size**: Adjust the slice limit in the leaderboard endpoint (default: top 10)
-- **Name Length**: Change the character limit for player names (default: 20 characters)
 
 ## 📝 Adding Questions
 

--- a/worker.js
+++ b/worker.js
@@ -9,9 +9,6 @@ function getBank(ids){
   return ids.flatMap(b => questions.slice((b - 1) * BANK_SIZE, b * BANK_SIZE));
 }
 
-// in-memory fallback for leaderboard when KV isn't available
-const memory = {};
-
 const app = new Hono();
 
 app.get('/api/banks', c => c.json({ bankCount, bankSize: BANK_SIZE }));
@@ -21,40 +18,6 @@ app.get('/api/bank/:ids', c => {
   if (!ids.length || ids.some(i => i < 1 || i > bankCount))
     return c.text('Invalid bank id', 400);
   return c.json(getBank(ids));
-});
-
-app.get('/api/leaderboard/:key', async c => {
-  const key = c.req.param('key');
-  const store = c.env?.LEADERBOARD;
-  let list;
-  if (store) {
-    list = await store.get(key, { type: 'json' }) ?? [];
-  } else {
-    list = memory[key] ?? [];
-  }
-  list = list.sort((a,b)=> b.score - a.score || a.time - b.time).slice(0,10);
-  return c.json(list);
-});
-
-app.post('/api/leaderboard/:key', async c => {
-  const key = c.req.param('key');
-  const { name, score, total, time } = await c.req.json();
-  if (!name || typeof score !== 'number') return c.text('Bad Request',400);
-  const store = c.env?.LEADERBOARD;
-  let list;
-  if (store) {
-    list = await store.get(key, { type: 'json' }) ?? [];
-  } else {
-    list = memory[key] ?? [];
-  }
-  list.push({ name: name.trim().slice(0,20), score, total, time });
-  list = list.sort((a,b)=> b.score - a.score || a.time - b.time).slice(0,10);
-  if (store) {
-    await store.put(key, JSON.stringify(list));
-  } else {
-    memory[key] = list;
-  }
-  return c.body(null, 201);
 });
 
 // serve static assets


### PR DESCRIPTION
## Summary
- drop leaderboard API routes and Cloudflare KV usage
- strip leaderboard UI and client-side calls
- revise documentation to reflect leaderboard removal

## Testing
- `npm test` *(fails: Missing script "test"*)
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_688fac65e520832d825e0afe3db47943